### PR TITLE
Document the `Revise.jl` requirement

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,13 @@
 
 GenieAutoReload monitors the indicated files and folders (recursively) and automatically recompiles the Julia code and reloads the corresponding browser window. 
 
-To use in the app, add the following lines of code: 
+To use, first make sure that you have installed [Revise.jl](https://github.com/timholy/Revise.jl) in your global environment, e.g.:
+```julia
+import Pkg
+Pkg.add("Revise")
+```
+
+Then, add the following lines of code to your app:
 
 ```julia
 using Genie, Genie.Renderer.Html # some app deps


### PR DESCRIPTION
This package requires that the user has `Revise.jl` installed in their global environment. For example, see this line:
https://github.com/GenieFramework/GenieAutoreload.jl/blob/e568e6f864f7795d1660148af627d4f010f68952/src/GenieAutoReload.jl#L4-L4

This pull request documents this requirement in the README.

cc: @essenciary 